### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/gitops/values.yaml
+++ b/src/gitops/values.yaml
@@ -122,7 +122,6 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: 2
     memory: 256Mi
   requests:
     cpu: 2


### PR DESCRIPTION
Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)