### PR TITLE
[SMP-1350]: Add support for extenal timescaleDB using helper functions

### DIFF
--- a/src/gitops/README.md
+++ b/src/gitops/README.md
@@ -82,6 +82,15 @@ Harness GitOps
 | global.database.postgres.protocol | string | `"postgres"` |  |
 | global.database.postgres.secretName | string | `""` |  |
 | global.database.postgres.userKey | string | `""` |  |
+| global.database.redis.extraArgs | string | `""` |  |
+| global.database.redis.hosts | list | `["redis:6379"]` | provide default values if redis.installed is set to false |
+| global.database.redis.installed | bool | `true` |  |
+| global.database.redis.passwordKey | string | `"redis-password"` |  |
+| global.database.redis.protocol | string | `"redis"` |  |
+| global.database.redis.secretName | string | `"redis-secret"` |  |
+| global.database.redis.userKey | string | `"redis-user"` |  |
+| global.database.timescaledb.certKey | string | `""` |  |
+| global.database.timescaledb.certName | string | `""` |  |
 | global.database.timescaledb.extraArgs | string | `""` |  |
 | global.database.timescaledb.hosts | list | `["timescaledb-single-chart:5432"]` | provide default values if mongo.installed is set to false |
 | global.database.timescaledb.installed | bool | `true` |  |
@@ -138,7 +147,6 @@ Harness GitOps
 | redis.sslCAPath | string | `""` |  |
 | redis.sslEnabled | string | `"false"` |  |
 | replicaCount | int | `1` |  |
-| resources.limits.cpu | int | `2` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | int | `2` |  |
 | resources.requests.memory | string | `"256Mi"` |  |

--- a/src/gitops/templates/config.yaml
+++ b/src/gitops/templates/config.yaml
@@ -37,10 +37,8 @@ data:
   GITOPS_SERVICE_MONGODB_DB_NAME: {{.Values.mongo.dbName | quote}}
   GITOPS_SERVICE_MONGODB_ENABLE_REFLECTION: {{.Values.mongo.enableReflection | quote}}
   GITOPS_SERVICE_TASK_LONG_POLLING: {{.Values.gitopsTaskLongPolling | quote}}
-  GITOPS_SERVICE_TIMESCALE_CERT_PATH: {{.Values.timescale.certPath | quote}}
   GITOPS_SERVICE_TIMESCALE_DB_NAME: {{.Values.timescale.dbName | quote}}
   GITOPS_SERVICE_TIMESCALE_LOG_LEVEL: {{.Values.timescale.logLevel | quote}}
-  GITOPS_SERVICE_TIMESCALE_USE_TLS: {{.Values.timescale.useTls | quote}}
   GITOPS_SERVICE_VERSION_FILE_LOCATION: {{.Values.versionFileLocation | quote}}
   IDENTITY_SERVICE_SECRET: {{.Values.identitySecret | quote}}
   JWT_SECRET: {{.Values.jwtSecret | quote}}

--- a/src/gitops/templates/deployment.yaml
+++ b/src/gitops/templates/deployment.yaml
@@ -59,18 +59,20 @@ spec:
           env:
             {{- include "harnesscommon.dbconnection.redisEnv" (dict "context" .Values.global.database.redis "userVariableName" "EVENTS_CONFIG_REDIS_USERNAME" "passwordVariableName" "REDIS_PASSWORD") | indent 12 }}
             {{- include "harnesscommon.dbconnection.mongoEnv" . | indent 12 }}
-            - name: TIMESCALE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.timescale.password.name }}
-                  key: {{ .Values.timescale.password.key }}
+            {{- include "harnesscommon.dbconnection.timescaleEnv" (dict "passwordVariableName" "TIMESCALE_PASSWORD" "userVariableName" "TIMESCALEDB_USERNAME" "context" $) | indent 12}}
+            {{- include "harnesscommon.dbconnection.timescaleSslEnv" (dict "enableSslVariableName" "GITOPS_SERVICE_TIMESCALE_USE_TLS" "certPathVariableName" "GITOPS_SERVICE_TIMESCALE_CERT_PATH" "certPathValue" "/opt/harness/svc/timescaledb-pem" "context" $ ) | nindent 12 }}
+            {{- $args := " "}}
+            {{- if .Values.global.database.timescaledb.installed }}
+            {{- $args = "sslmode=disable" }}
+            {{- else }}
+            {{- $args = "sslmode=require" }}
+            {{- end }}
             - name: GITOPS_SERVICE_TIMESCALE_URL
-              value:  postgres://postgres:$(TIMESCALE_PASSWORD)@timescaledb-single-chart.{{ .Release.Namespace }}:5432/harness_gitops?sslmode=disable
+              value: {{ include "harnesscommon.dbconnection.timescaleConnection" (dict "protocol" "postgres" "userVariableName" "TIMESCALEDB_USERNAME" "passwordVariableName" "TIMESCALE_PASSWORD" "database" "harness_gitops" "args" $args "context" $) }}
             - name: GITOPS_SMP_ADMIN_TIMESCALE_URL
-              value:  postgres://postgres:$(TIMESCALE_PASSWORD)@timescaledb-single-chart.{{ .Release.Namespace }}:5432/?sslmode=disable
+              value: {{ include "harnesscommon.dbconnection.timescaleConnection" (dict "protocol" "postgres" "userVariableName" "TIMESCALEDB_USERNAME" "passwordVariableName" "TIMESCALE_PASSWORD" "database" "" "args" $args "context" $) }}
             - name: GITOPS_SERVICE_MONGODB_URL
               value: {{ include "harnesscommon.dbconnection.mongoConnection" (dict "database" "harness-gitops" "context" $) }}
-
           livenessProbe:
             httpGet:
               path: /healthz
@@ -85,6 +87,18 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if not .Values.global.database.timescaledb.installed }}
+          volumeMounts:
+            - name: timescaledb-cert
+              mountPath: /opt/harness/svc
+      volumes:
+      - name: timescaledb-cert
+        secret:
+          secretName: {{ .Values.global.database.timescaledb.certName }}
+          items:
+          - key: {{ .Values.global.database.timescaledb.certKey }}
+            path: timescaledb-pem
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/src/gitops/values.yaml
+++ b/src/gitops/values.yaml
@@ -41,6 +41,8 @@ global:
       userKey: ""
       passwordKey: ""
       extraArgs: ""
+      certName: ""
+      certKey: ""
     redis:
       installed: true
       protocol: "redis"


### PR DESCRIPTION
Support for external timescale, it uses
{{/* Generates Timescale Connection string
{{ include "harnesscommon.dbconnection.timescaleConnection" (dict "database" "foo" "args" "bar" "context" $) }}
*/}}
{{- define "harnesscommon.dbconnection.timescaleConnection2" }}
{{- $host := include "harnesscommon.dbconnection.timescaleHost" (dict "context" .context ) }}
{{- $port := include "harnesscommon.dbconnection.timescalePort" (dict "context" .context ) }}
{{- $connectionString := "" }}
{{- $protocol := "" }}
{{- if not (empty .protocol) }}
{{- $protocol = (printf "%s://" .protocol) }}
{{- end }}
{{- $userAndPassField := "" }}
{{- if and (.userVariableName) (.passwordVariableName) }}
{{- $userAndPassField = (printf "$(%s):$(%s)@" .userVariableName .passwordVariableName) }}
{{- end }}
{{- $connectionString = (printf "%s%s%s:%s/%s" $protocol $userAndPassField  $host $port .database) }}
{{- if .args }}
{{- $connectionString = (printf "%s?%s" $connectionString .args) }}
{{- end }}
{{- printf "%s" $connectionString -}}
{{- end }}